### PR TITLE
Add Windows install helper and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ Prerequisites: Node.js 18+
 4. Run dev server:
    npm run dev
 
+### Windows Install Helper
+
+For Windows, you can run the helper script to install dependencies, set the API key, build, and package the app:
+
+```powershell
+.\scripts\windows\install.ps1 -ApiKey "sk-..." 
+```
+
+Optional flags:
+
+* `-SkipInstall` to skip `npm install`
+* `-SkipBuild` to skip the production build
+
+The script outputs `dist.zip` using `Compress-Archive`.
+
 ## Build
 
 Production bundle (outputs to `dist/`):
@@ -152,4 +167,3 @@ Do NOT expose sensitive production keys directly to the client. For production, 
 ## License
 
 MIT (add a LICENSE file if distributing publicly).
-

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint . --ext .ts,.tsx",
-  "lint:fix": "eslint . --ext .ts,.tsx --fix",
-  "bundle:zip": "rm -f dist.zip 2>NUL || true && zip -r dist.zip dist"
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "bundle:zip": "rm -f dist.zip 2>NUL || true && zip -r dist.zip dist",
+    "install:win": "powershell -ExecutionPolicy Bypass -File scripts/windows/install.ps1"
   },
   "dependencies": {
     "@google/genai": "^1.11.0",

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -1,0 +1,52 @@
+param(
+  [string]$ApiKey = "",
+  [switch]$SkipInstall,
+  [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+function Require-Command {
+  param([string]$Name)
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    Write-Error "Required command '$Name' not found. Install it and try again."
+    exit 1
+  }
+}
+
+Require-Command "node"
+Require-Command "npm"
+
+if (-not $SkipInstall) {
+  npm install --legacy-peer-deps
+}
+
+if (-not (Test-Path ".env.local")) {
+  Copy-Item ".env.example" ".env.local"
+}
+
+if ($ApiKey) {
+  $envLines = @()
+  if (Test-Path ".env.local") {
+    $envLines = Get-Content ".env.local"
+  }
+
+  if ($envLines -match "^GEMINI_API_KEY=") {
+    $envLines = $envLines -replace "^GEMINI_API_KEY=.*", "GEMINI_API_KEY=$ApiKey"
+  } else {
+    $envLines += "GEMINI_API_KEY=$ApiKey"
+  }
+
+  Set-Content ".env.local" $envLines
+}
+
+if (-not $SkipBuild) {
+  npm run build
+}
+
+if (Test-Path "dist") {
+  if (Test-Path "dist.zip") {
+    Remove-Item "dist.zip" -Force
+  }
+  Compress-Archive -Path "dist/*" -DestinationPath "dist.zip"
+}


### PR DESCRIPTION
### Motivation

- Provide a simple Windows-friendly helper to automate installing dependencies, setting the API key, building, and packaging the app.
- Make it easy for Windows users to produce a redistributable `dist.zip` and configure `GEMINI_API_KEY` without manual edits.

### Description

- Add a PowerShell helper `scripts/windows/install.ps1` that verifies `node`/`npm`, runs `npm install --legacy-peer-deps` (unless `-SkipInstall`), copies `.env.example` to `.env.local` if missing, injects `GEMINI_API_KEY` when `-ApiKey` is provided, runs `npm run build` (unless `-SkipBuild`), and creates `dist.zip` with `Compress-Archive`.
- Add an npm script `install:win` to `package.json` which invokes the helper via `powershell -ExecutionPolicy Bypass -File scripts/windows/install.ps1`.
- Document the Windows helper and usage example in `README.md`, including the `-SkipInstall` and `-SkipBuild` flags.

### Testing

- Attempted `npm install --legacy-peer-deps` in the environment but the process hung and was interrupted before completion.
- No automated test suites (for example `npm test` / `vitest`) were executed due to the interrupted dependency installation.
- The PowerShell script file was reviewed in the repository but not executed end-to-end in CI or this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f41bf11b0832ca8eee230515c8c18)