### PR TITLE
Improve Windows install helper and README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ Prerequisites: Node.js 18+
 4. Run dev server:
    npm run dev
 
+### Windows Install Helper
+
+For Windows, you can run the helper script to install dependencies, set the API key, build, and package the app:
+
+```powershell
+.\scripts\windows\install.ps1 -ApiKey "sk-..."
+```
+
+Or via npm (pass args after `--`):
+
+```powershell
+npm run install:win -- -ApiKey "sk-..."
+```
+
+Optional flags:
+
+* `-SkipInstall` to skip `npm install`
+* `-SkipBuild` to skip the production build
+
+The script outputs `dist.zip` using `Compress-Archive`.
+
 ## Build
 
 Production bundle (outputs to `dist/`):
@@ -152,4 +173,3 @@ Do NOT expose sensitive production keys directly to the client. For production, 
 ## License
 
 MIT (add a LICENSE file if distributing publicly).
-

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint . --ext .ts,.tsx",
-  "lint:fix": "eslint . --ext .ts,.tsx --fix",
-  "bundle:zip": "rm -f dist.zip 2>NUL || true && zip -r dist.zip dist"
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "bundle:zip": "rm -f dist.zip 2>NUL || true && zip -r dist.zip dist",
+    "install:win": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/install.ps1"
   },
   "dependencies": {
     "@google/genai": "^1.11.0",

--- a/scripts/windows/install.ps1
+++ b/scripts/windows/install.ps1
@@ -1,0 +1,62 @@
+param(
+  [string]$ApiKey = "",
+  [switch]$SkipInstall,
+  [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Require-Command {
+  param([string]$Name)
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    Write-Error "Required command '$Name' not found. Install it and try again."
+    exit 1
+  }
+}
+
+Require-Command "node"
+Require-Command "npm"
+
+if (-not $SkipInstall) {
+  Write-Host "Installing dependencies..." -ForegroundColor Cyan
+  npm install --legacy-peer-deps
+}
+
+if (-not (Test-Path ".env.local")) {
+  if (-not (Test-Path ".env.example")) {
+    Write-Error "Missing .env.example; create .env.local manually or restore the template."
+    exit 1
+  }
+  Copy-Item ".env.example" ".env.local"
+}
+
+if ($ApiKey) {
+  $envLines = @()
+  if (Test-Path ".env.local") {
+    $envLines = Get-Content ".env.local"
+  }
+
+  if ($envLines -match "^GEMINI_API_KEY=") {
+    $envLines = $envLines -replace "^GEMINI_API_KEY=.*", "GEMINI_API_KEY=$ApiKey"
+  } else {
+    $envLines += "GEMINI_API_KEY=$ApiKey"
+  }
+
+  Set-Content ".env.local" $envLines -Encoding UTF8
+}
+
+if (-not $SkipBuild) {
+  Write-Host "Building production bundle..." -ForegroundColor Cyan
+  npm run build
+}
+
+if (Test-Path "dist") {
+  if (Test-Path "dist.zip") {
+    Remove-Item "dist.zip" -Force
+  }
+  Write-Host "Packaging dist.zip..." -ForegroundColor Cyan
+  Compress-Archive -Path "dist/*" -DestinationPath "dist.zip"
+} else {
+  Write-Warning "dist/ not found; skipping dist.zip packaging."
+}


### PR DESCRIPTION
### Motivation

- Make the Windows install helper safer and more predictable by adding stricter error handling and explicit checks.  
- Ensure environment template handling and API key injection are robust and encoded correctly.  
- Provide clear user feedback during install/build/package steps.  

### Description

- Enable strict PowerShell mode and add `Require-Command` checks for `node` and `npm`, failing early if missing.  
- Copy `.env.example` to `.env.local` only when present and inject `GEMINI_API_KEY` into `.env.local`, writing with `-Encoding UTF8`.  
- Add status output (`Write-Host`) for major steps, add packaging via `Compress-Archive`, and warn if `dist/` is missing.  
- Update `package.json` `install:win` to run PowerShell with `-NoProfile` and document npm invocation in `README.md` (usage via `npm run install:win -- -ApiKey "sk-..."`).

### Testing

- No automated tests were executed because dependency installation previously hung when attempting `npm install --legacy-peer-deps`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f41bf11b0832ca8eee230515c8c18)