### PR TITLE
feat: add Hugging Face NER endpoint and UI integration

### DIFF
--- a/__tests__/VerisBertaNerView.test.tsx
+++ b/__tests__/VerisBertaNerView.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import VerisBertaNerView from '../components/VerisBertaNerView';
+
+vi.mock('../services/nerService', () => ({
+  runNerAnalysis: vi.fn(),
+}));
+
+import { runNerAnalysis } from '../services/nerService';
+
+describe('VerisBertaNerView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state while request is in progress', async () => {
+    (runNerAnalysis as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    render(<VerisBertaNerView />);
+    fireEvent.change(screen.getByLabelText(/incident narrative/i), {
+      target: { value: 'LockBit accessed VPN account and deployed ransomware.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /run ner analysis/i }));
+
+    expect(screen.getByText(/running ner analysis/i)).toBeInTheDocument();
+  });
+
+  it('shows error state when API fails', async () => {
+    (runNerAnalysis as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Hugging Face rate limit reached. Please retry shortly.'),
+    );
+
+    render(<VerisBertaNerView />);
+    fireEvent.change(screen.getByLabelText(/incident narrative/i), {
+      target: { value: 'Example narrative text' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /run ner analysis/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/rate limit/i);
+    });
+  });
+
+  it('shows success grouped panels and truncated warning', async () => {
+    (runNerAnalysis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      model: { name: 'org/model', revision: 'main', labels: ['ACTOR', 'ASSET', 'ACTION', 'ATTRIBUTE', 'OTHER'] },
+      limits: { maxChars: 12000, truncated: true },
+      entities: [
+        {
+          category: 'ACTOR',
+          text: 'LockBit',
+          start: 0,
+          end: 7,
+          confidence: 0.91,
+          source: 'model',
+          originalLabel: 'B-ACTOR',
+          normalized: { veris: {} },
+        },
+      ],
+      grouped: {
+        ACTOR: [
+          {
+            category: 'ACTOR',
+            text: 'LockBit',
+            start: 0,
+            end: 7,
+            confidence: 0.91,
+            source: 'model',
+            originalLabel: 'B-ACTOR',
+            normalized: { veris: {} },
+          },
+        ],
+        ASSET: [],
+        ACTION: [],
+        ATTRIBUTE: [],
+        OTHER: [],
+      },
+      warnings: ['Assistive output; analyst review required.'],
+      telemetry: { latencyMs: 120, emptyExtraction: false, inputChars: 100, requestId: 'req-1' },
+    });
+
+    render(<VerisBertaNerView />);
+    fireEvent.change(screen.getByLabelText(/incident narrative/i), {
+      target: { value: 'LockBit accessed VPN account and deployed ransomware.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /run ner analysis/i }));
+
+    await waitFor(() => {
+      const modelLine = screen.getByText(/Model:/i);
+      expect(modelLine).toHaveTextContent('org/model');
+      expect(modelLine).toHaveTextContent('(main)');
+      expect(screen.getByText(/Input exceeded 12,000 characters and was truncated/i)).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /Actor/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/nerServer.test.ts
+++ b/__tests__/nerServer.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createNerHandler, __testables } from '../server/nerServer';
+
+const buildReq = (body: unknown) => {
+  const listeners: Record<string, ((arg?: any) => void)[]> = {};
+  const req = {
+    method: 'POST',
+    url: '/api/ner',
+    on(event: string, cb: (arg?: any) => void) {
+      listeners[event] = listeners[event] || [];
+      listeners[event].push(cb);
+    },
+  } as any;
+
+  queueMicrotask(() => {
+    const payload = JSON.stringify(body);
+    (listeners.data || []).forEach((cb) => cb(payload));
+    (listeners.end || []).forEach((cb) => cb());
+  });
+
+  return req;
+};
+
+const buildRes = () => {
+  let statusCode = 0;
+  let raw = '';
+  return {
+    res: {
+      writeHead(code: number) {
+        statusCode = code;
+      },
+      end(chunk: string) {
+        raw = chunk;
+      },
+    } as any,
+    get statusCode() {
+      return statusCode;
+    },
+    json<T = any>() {
+      return JSON.parse(raw) as T;
+    },
+  };
+};
+
+describe('nerServer backend endpoint scenarios', () => {
+  it('missing HF_API_TOKEN returns safe config error', async () => {
+    const { handler } = createNerHandler({
+      env: { HF_API_TOKEN: '', HF_NER_MODEL: 'org/model' } as any,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      logger: vi.fn(),
+    });
+
+    const out = buildRes();
+    await handler(buildReq({ text: 'hello' }), out.res);
+
+    expect(out.statusCode).toBe(500);
+    expect(out.json().error).toMatch(/HF_API_TOKEN is missing/i);
+  });
+
+  it('missing HF_NER_MODEL returns safe config error', async () => {
+    const { handler } = createNerHandler({
+      env: { HF_API_TOKEN: 'token', HF_NER_MODEL: '' } as any,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      logger: vi.fn(),
+    });
+
+    const out = buildRes();
+    await handler(buildReq({ text: 'hello' }), out.res);
+
+    expect(out.statusCode).toBe(500);
+    expect(out.json().error).toMatch(/HF_NER_MODEL is missing/i);
+  });
+
+  it('timeout returns 504 safe error', async () => {
+    const fetchImpl = vi.fn(async () => {
+      const err: any = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    });
+
+    const { handler } = createNerHandler({
+      env: { HF_API_TOKEN: 'token', HF_NER_MODEL: 'org/model', NER_API_TIMEOUT_MS: '1' } as any,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: vi.fn(),
+    });
+
+    const out = buildRes();
+    await handler(buildReq({ text: 'hello' }), out.res);
+
+    expect(out.statusCode).toBe(504);
+    expect(out.json().error).toMatch(/timed out/i);
+  });
+
+  it('429 upstream returns safe rate-limit error', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      status: 429,
+      ok: false,
+      text: async () => '{"error":"rate"}',
+    }));
+
+    const { handler } = createNerHandler({
+      env: { HF_API_TOKEN: 'token', HF_NER_MODEL: 'org/model' } as any,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: vi.fn(),
+    });
+
+    const out = buildRes();
+    await handler(buildReq({ text: 'hello' }), out.res);
+
+    expect(out.statusCode).toBe(503);
+    expect(out.json().error).toMatch(/rate limit/i);
+  });
+
+  it('503 upstream returns safe model-loading error', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      status: 503,
+      ok: false,
+      text: async () => '{"error":"loading"}',
+    }));
+
+    const { handler } = createNerHandler({
+      env: { HF_API_TOKEN: 'token', HF_NER_MODEL: 'org/model' } as any,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: vi.fn(),
+    });
+
+    const out = buildRes();
+    await handler(buildReq({ text: 'hello' }), out.res);
+
+    expect(out.statusCode).toBe(503);
+    expect(out.json().error).toMatch(/loading or unavailable/i);
+  });
+
+  it('malformed/non-JSON upstream response returns safe upstream error', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      status: 200,
+      ok: false,
+      text: async () => 'not-json',
+    }));
+
+    const { handler } = createNerHandler({
+      env: { HF_API_TOKEN: 'token', HF_NER_MODEL: 'org/model' } as any,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: vi.fn(),
+    });
+
+    const out = buildRes();
+    await handler(buildReq({ text: 'hello' }), out.res);
+
+    expect(out.statusCode).toBe(502);
+    expect(out.json().error).toMatch(/Upstream model error/i);
+  });
+
+  it('grouped response shape includes ACTOR/ASSET/ACTION/ATTRIBUTE/OTHER', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      status: 200,
+      ok: true,
+      text: async () => JSON.stringify([{ entity: 'B-ACTOR', word: 'LockBit', start: 0, end: 7, score: 0.9 }]),
+    }));
+
+    const { handler } = createNerHandler({
+      env: { HF_API_TOKEN: 'token', HF_NER_MODEL: 'org/model' } as any,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      logger: vi.fn(),
+    });
+
+    const out = buildRes();
+    await handler(buildReq({ text: 'incident text' }), out.res);
+
+    expect(out.statusCode).toBe(200);
+    const body = out.json();
+    expect(body.grouped).toHaveProperty('ACTOR');
+    expect(body.grouped).toHaveProperty('ASSET');
+    expect(body.grouped).toHaveProperty('ACTION');
+    expect(body.grouped).toHaveProperty('ATTRIBUTE');
+    expect(body.grouped).toHaveProperty('OTHER');
+  });
+});
+
+describe('nerServer normalization and merge behavior', () => {
+  it('normalizes BIO + aliases and unknown -> OTHER', () => {
+    expect(__testables.normalizeCategory('B-ACTOR')).toBe('ACTOR');
+    expect(__testables.normalizeCategory('I-THREAT_ACTOR')).toBe('ACTOR');
+    expect(__testables.normalizeCategory('TECHNIQUE')).toBe('ACTION');
+    expect(__testables.normalizeCategory('SOMETHING_NEW')).toBe('OTHER');
+  });
+
+  it('merges BIO/subword tokens into clean combined spans', () => {
+    const tokens = [
+      { entity: 'B-ACTOR', word: 'Lock', start: 0, end: 4, score: 0.9 },
+      { entity: 'I-ACTOR', word: '##Bit', start: 4, end: 7, score: 0.8 },
+      { entity: 'B-ACTION', word: ' deployed', start: 8, end: 16, score: 0.7 },
+      { entity: 'I-ACTION', word: ' ransomware', start: 17, end: 27, score: 0.7 },
+    ].map(__testables.toToken);
+
+    const entities = __testables.mergeTokensToEntities(tokens);
+    expect(entities.length).toBe(2);
+    expect(entities[0].category).toBe('ACTOR');
+    expect(entities[0].text).toBe('LockBit');
+    expect(entities[0].start).toBe(0);
+    expect(entities[0].end).toBe(7);
+    expect(entities[1].category).toBe('ACTION');
+    expect(entities[1].text).toContain('deployed');
+    expect(entities[1].text).toContain('ransomware');
+  });
+});

--- a/components/VerisBertaNerView.tsx
+++ b/components/VerisBertaNerView.tsx
@@ -1,0 +1,191 @@
+import React, { useMemo, useState } from 'react';
+import LoadingSpinner from './shared/LoadingSpinner';
+import { runNerAnalysis, NERCategory, NEREntity, NERResponse } from '../services/nerService';
+
+const CATEGORY_TITLES: Record<NERCategory, string> = {
+  ACTOR: 'Actor',
+  ASSET: 'Asset',
+  ACTION: 'Action',
+  ATTRIBUTE: 'Attribute',
+  OTHER: 'Other',
+};
+
+type ReviewState = 'accepted' | 'edited' | 'ignored' | 'unreviewed';
+
+const EntityRow: React.FC<{ entity: NEREntity }> = ({ entity }) => {
+  const [reviewState, setReviewState] = useState<ReviewState>('unreviewed');
+  const [editedText, setEditedText] = useState(entity.text);
+
+  return (
+    <li className="rounded-lg border border-dark-border bg-gray-900/50 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="font-semibold text-white">{editedText}</p>
+          <p className="text-sm text-dark-text-secondary">
+            {entity.category}
+            {typeof entity.confidence === 'number' ? ` • ${(entity.confidence * 100).toFixed(1)}%` : ''}
+            {typeof entity.start === 'number' && typeof entity.end === 'number'
+              ? ` • span ${entity.start}-${entity.end}`
+              : ''}
+          </p>
+        </div>
+        <div className="inline-flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setReviewState('accepted')}
+            className="rounded-md border border-green-600/40 px-2 py-1 text-xs text-green-300 hover:bg-green-900/30 focus:outline-none focus:ring-2 focus:ring-green-500"
+          >
+            Accept
+          </button>
+          <button
+            type="button"
+            onClick={() => setReviewState('edited')}
+            className="rounded-md border border-yellow-600/40 px-2 py-1 text-xs text-yellow-300 hover:bg-yellow-900/30 focus:outline-none focus:ring-2 focus:ring-yellow-500"
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={() => setReviewState('ignored')}
+            className="rounded-md border border-red-600/40 px-2 py-1 text-xs text-red-300 hover:bg-red-900/30 focus:outline-none focus:ring-2 focus:ring-red-500"
+          >
+            Ignore
+          </button>
+        </div>
+      </div>
+
+      {reviewState === 'edited' && (
+        <div className="mt-2">
+          <label className="sr-only" htmlFor={`edit-${entity.start ?? 'na'}-${entity.end ?? 'na'}`}>
+            Edit extracted entity text
+          </label>
+          <input
+            id={`edit-${entity.start ?? 'na'}-${entity.end ?? 'na'}`}
+            value={editedText}
+            onChange={(e) => setEditedText(e.target.value)}
+            className="w-full rounded-md border border-dark-border bg-gray-950 px-2 py-1 text-sm text-white focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+        </div>
+      )}
+
+      <p className="mt-2 text-xs text-dark-text-secondary">Review: {reviewState}</p>
+    </li>
+  );
+};
+
+const GroupPanel: React.FC<{ category: NERCategory; entities: NEREntity[] }> = ({ category, entities }) => {
+  return (
+    <section className="rounded-xl border border-dark-border bg-dark-card p-4" aria-label={`${CATEGORY_TITLES[category]} entities`}>
+      <h3 className="mb-3 text-lg font-semibold text-white">{CATEGORY_TITLES[category]}</h3>
+      {entities.length === 0 ? (
+        <p className="text-sm text-dark-text-secondary">No entities detected.</p>
+      ) : (
+        <ul className="space-y-3">
+          {entities.map((entity, index) => (
+            <EntityRow key={`${category}-${entity.start ?? index}-${entity.text}-${index}`} entity={entity} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+const VerisBertaNerView: React.FC = () => {
+  const [text, setText] = useState('');
+  const [result, setResult] = useState<NERResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const hasInput = useMemo(() => text.trim().length > 0, [text]);
+
+  const onSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await runNerAnalysis(text);
+      setResult(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'NER analysis failed.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-6xl px-4 pb-24 md:pb-8">
+      <div className="rounded-xl border border-dark-border bg-dark-card p-5">
+        <h2 className="text-xl font-bold text-white">SOC Incident Narrative Enrichment</h2>
+        <p className="mt-1 text-sm text-dark-text-secondary">Assistive output; analyst review required.</p>
+
+        <div className="mt-4">
+          <label htmlFor="incident-text" className="mb-2 block text-sm font-medium text-white">
+            Incident narrative
+          </label>
+          <textarea
+            id="incident-text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Paste incident narrative, breach report, alert, or VERIS/VCDB-style description..."
+            className="min-h-[180px] w-full rounded-lg border border-dark-border bg-gray-950 p-3 text-white focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+          <p className="mt-2 text-xs text-dark-text-secondary">{text.length} chars (max 12,000 processed)</p>
+        </div>
+
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={!hasInput || loading}
+            className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 font-semibold text-gray-900 hover:bg-accent-hover disabled:cursor-not-allowed disabled:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-accent"
+          >
+            {loading ? <LoadingSpinner size={18} /> : null}
+            {loading ? 'Running NER Analysis...' : 'Run NER Analysis'}
+          </button>
+        </div>
+
+        {error && (
+          <div role="alert" className="mt-4 rounded-lg border border-red-700 bg-red-900/40 p-3 text-red-200">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && result?.entities.length === 0 && (
+          <div className="mt-4 rounded-lg border border-dark-border bg-gray-900/50 p-3 text-dark-text-secondary">
+            No entities detected. Try a longer or more specific incident narrative.
+          </div>
+        )}
+
+        {result && (
+          <div className="mt-6 space-y-4">
+            <div className="rounded-lg border border-dark-border bg-gray-900/40 p-3 text-sm text-dark-text-secondary">
+              <p>
+                Model: <span className="text-white">{result.model.name}</span> ({result.model.revision})
+              </p>
+              <p>
+                Request ID: <span className="text-white">{result.telemetry.requestId}</span> • Latency:{' '}
+                <span className="text-white">{result.telemetry.latencyMs}ms</span>
+              </p>
+              {result.limits.truncated ? (
+                <p className="text-yellow-300">
+                  Input exceeded 12,000 characters and was truncated for API safety. Model token-window chunking is not applied yet.
+                </p>
+              ) : null}
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <GroupPanel category="ACTOR" entities={result.grouped.ACTOR} />
+              <GroupPanel category="ASSET" entities={result.grouped.ASSET} />
+              <GroupPanel category="ACTION" entities={result.grouped.ACTION} />
+              <GroupPanel category="ATTRIBUTE" entities={result.grouped.ATTRIBUTE} />
+              <GroupPanel category="OTHER" entities={result.grouped.OTHER} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default VerisBertaNerView;

--- a/server/nerServer.js
+++ b/server/nerServer.js
@@ -1,0 +1,438 @@
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+const PORT = Number(process.env.NER_API_PORT || 8787);
+const HF_API_TOKEN = process.env.HF_API_TOKEN?.trim() || '';
+const HF_NER_MODEL = process.env.HF_NER_MODEL?.trim() || '';
+const MODEL_REVISION = process.env.MODEL_REVISION?.trim() || '';
+const REQUEST_TIMEOUT_MS = Number(process.env.NER_API_TIMEOUT_MS || 8000);
+const MAX_CHARS = 12000;
+const CATEGORY_LABELS = ['ACTOR', 'ASSET', 'ACTION', 'ATTRIBUTE', 'OTHER'];
+
+const GROUPED_EMPTY = {
+  ACTOR: [],
+  ASSET: [],
+  ACTION: [],
+  ATTRIBUTE: [],
+  OTHER: [],
+};
+
+const json = (res, status, payload) => {
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify(payload));
+};
+
+const safeLog = (requestId, message, meta = {}) => {
+  const scrubbed = { ...meta };
+  delete scrubbed.text;
+  delete scrubbed.input;
+  delete scrubbed.raw;
+  console.log(`[ner][${requestId}] ${message}`, scrubbed);
+};
+
+const splitBioPrefix = (rawLabel) => {
+  const label = String(rawLabel || '').toUpperCase().trim();
+  const matched = label.match(/^([BIES])[-_](.+)$/);
+  if (!matched) {
+    return { bio: null, base: label };
+  }
+  return { bio: matched[1], base: matched[2] || '' };
+};
+
+const normalizeCategory = (rawLabel) => {
+  const { base } = splitBioPrefix(rawLabel);
+  if (!base || base === 'O') {
+    return 'OTHER';
+  }
+
+  const aliases = new Map([
+    ['THREAT_ACTOR', 'ACTOR'],
+    ['ATTACKER', 'ACTOR'],
+    ['INFRASTRUCTURE', 'ASSET'],
+    ['SYSTEM', 'ASSET'],
+    ['ACCOUNT', 'ASSET'],
+    ['TARGET', 'ASSET'],
+    ['HOST', 'ASSET'],
+    ['TTP', 'ACTION'],
+    ['TECHNIQUE', 'ACTION'],
+    ['TACTIC', 'ACTION'],
+    ['VULNERABILITY', 'ATTRIBUTE'],
+    ['MALWARE', 'ATTRIBUTE'],
+    ['IOC', 'ATTRIBUTE'],
+    ['INDICATOR', 'ATTRIBUTE'],
+  ]);
+
+  if (CATEGORY_LABELS.includes(base)) {
+    return base;
+  }
+
+  if (aliases.has(base)) {
+    return aliases.get(base);
+  }
+
+  if (base.includes('ACTOR')) return 'ACTOR';
+  if (base.includes('ASSET')) return 'ASSET';
+  if (base.includes('ACTION')) return 'ACTION';
+  if (base.includes('ATTRIBUTE')) return 'ATTRIBUTE';
+
+  return 'OTHER';
+};
+
+const maybeMapVeris = (text, category) => {
+  const t = String(text || '').toLowerCase();
+  if (category === 'ACTION' && t.includes('phish')) {
+    return { action: { social: { variety: 'phishing' } } };
+  }
+  if (category === 'ACTION' && t.includes('ransom')) {
+    return { action: { malware: { variety: 'ransomware' } } };
+  }
+  return {};
+};
+
+const decodeTokenText = (token) => {
+  const raw = String(token ?? '');
+  const normalized = raw.replace(/Ġ/g, ' ').replace(/▁/g, ' ');
+  if (normalized.startsWith('##')) return normalized.slice(2);
+  return normalized;
+};
+
+const extractTokenRows = (hfPayload) => {
+  if (Array.isArray(hfPayload)) {
+    if (hfPayload.length > 0 && Array.isArray(hfPayload[0])) {
+      return hfPayload.flat();
+    }
+    return hfPayload;
+  }
+  return [];
+};
+
+const toToken = (row) => {
+  const rawLabel = row.entity ?? row.entity_group ?? row.label ?? '';
+  const { bio } = splitBioPrefix(rawLabel);
+  const tokenText = row.word ?? row.text ?? '';
+  const text = decodeTokenText(tokenText);
+  return {
+    rawLabel: String(rawLabel || 'UNKNOWN'),
+    bio,
+    category: normalizeCategory(rawLabel),
+    text,
+    start: Number.isFinite(row.start) ? row.start : null,
+    end: Number.isFinite(row.end) ? row.end : null,
+    confidence: typeof row.score === 'number' ? row.score : null,
+  };
+};
+
+const isSubwordJoin = (text) => {
+  if (!text) return false;
+  return !/^\s/.test(text);
+};
+
+const mergeTokensToEntities = (tokens) => {
+  const entities = [];
+  let current = null;
+
+  const flush = () => {
+    if (!current || !current.text.trim()) return;
+    entities.push({
+      category: current.category,
+      text: current.text.trim(),
+      start: current.start,
+      end: current.end,
+      confidence: current.confidenceTotal / current.confidenceCount,
+      source: 'model',
+      originalLabel: current.originalLabel,
+      normalized: {
+        veris: maybeMapVeris(current.text, current.category),
+      },
+    });
+    current = null;
+  };
+
+  for (const token of tokens) {
+    if (!token.text || token.category === 'OTHER') {
+      flush();
+      continue;
+    }
+
+    const canContinue =
+      current &&
+      current.category === token.category &&
+      token.bio !== 'B' &&
+      typeof current.end === 'number' &&
+      typeof token.start === 'number' &&
+      token.start <= current.end + 1;
+
+    if (!canContinue) {
+      flush();
+      current = {
+        category: token.category,
+        text: token.text,
+        start: token.start,
+        end: token.end,
+        confidenceTotal: token.confidence ?? 0,
+        confidenceCount: token.confidence == null ? 0 : 1,
+        originalLabel: token.rawLabel,
+      };
+      continue;
+    }
+
+    current.text += isSubwordJoin(token.text) ? token.text : ` ${token.text.trimStart()}`;
+    if (typeof token.end === 'number') {
+      current.end = token.end;
+    }
+    if (typeof token.confidence === 'number') {
+      current.confidenceTotal += token.confidence;
+      current.confidenceCount += 1;
+    }
+  }
+
+  flush();
+  return entities.map((entity) => ({
+    ...entity,
+    confidence: Number.isFinite(entity.confidence) ? entity.confidence : null,
+  }));
+};
+
+const groupEntities = (entities) =>
+  entities.reduce(
+    (acc, entity) => {
+      acc[entity.category].push(entity);
+      return acc;
+    },
+    { ...GROUPED_EMPTY },
+  );
+
+const readBody = (req) =>
+  new Promise((resolve, reject) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+      if (raw.length > 1024 * 1024) {
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => resolve(raw));
+    req.on('error', reject);
+  });
+
+const parseUpstreamBody = async (response) => {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { nonJsonBody: true };
+  }
+};
+
+const callHuggingFace = async (text) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const endpoint = `https://api-inference.huggingface.co/models/${encodeURIComponent(HF_NER_MODEL)}${MODEL_REVISION ? `?revision=${encodeURIComponent(MODEL_REVISION)}` : ''}`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${HF_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        inputs: text,
+        options: {
+          wait_for_model: true,
+          use_cache: true,
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    const payload = await parseUpstreamBody(response);
+    return { response, payload };
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const safeError = (res, status, error) => json(res, status, { success: false, error });
+
+export const __testables = {
+  splitBioPrefix,
+  normalizeCategory,
+  decodeTokenText,
+  extractTokenRows,
+  toToken,
+  mergeTokensToEntities,
+  groupEntities,
+  parseUpstreamBody,
+};
+
+export const createNerHandler = ({
+  env = process.env,
+  fetchImpl = fetch,
+  now = () => Date.now(),
+  uuid = () => randomUUID(),
+  logger = safeLog,
+} = {}) => {
+  const port = Number(env.NER_API_PORT || 8787);
+  const hfApiToken = env.HF_API_TOKEN?.trim() || '';
+  const hfNerModel = env.HF_NER_MODEL?.trim() || '';
+  const modelRevision = env.MODEL_REVISION?.trim() || '';
+  const requestTimeoutMs = Number(env.NER_API_TIMEOUT_MS || 8000);
+  const maxChars = MAX_CHARS;
+
+  const callHuggingFaceLocal = async (text) => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+    const endpoint = `https://api-inference.huggingface.co/models/${encodeURIComponent(hfNerModel)}${modelRevision ? `?revision=${encodeURIComponent(modelRevision)}` : ''}`;
+
+    try {
+      const response = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${hfApiToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          inputs: text,
+          options: {
+            wait_for_model: true,
+            use_cache: true,
+          },
+        }),
+        signal: controller.signal,
+      });
+
+      const payload = await parseUpstreamBody(response);
+      return { response, payload };
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+
+  const handler = async (req, res) => {
+    const start = now();
+    const requestId = uuid();
+
+    if (req.method !== 'POST' || req.url !== '/api/ner') {
+      return safeError(res, 404, 'Not Found');
+    }
+
+    try {
+      if (!hfApiToken) {
+        logger(requestId, 'missing_token');
+        return safeError(res, 500, 'Server misconfiguration: HF_API_TOKEN is missing.');
+      }
+      if (!hfNerModel) {
+        logger(requestId, 'missing_model');
+        return safeError(
+          res,
+          500,
+          'Server misconfiguration: HF_NER_MODEL is missing. Configure a fine-tuned token-classification model.',
+        );
+      }
+
+      const raw = await readBody(req);
+      let parsed;
+      try {
+        parsed = raw ? JSON.parse(raw) : {};
+      } catch {
+        return safeError(res, 400, 'Invalid JSON body.');
+      }
+      if (!parsed || typeof parsed !== 'object') {
+        return safeError(res, 400, 'Malformed request body.');
+      }
+
+      const textInput = typeof parsed.text === 'string' ? parsed.text : '';
+      if (!textInput.trim()) {
+        return safeError(res, 400, 'Input text is required.');
+      }
+
+      const truncated = textInput.length > maxChars;
+      const text = truncated ? textInput.slice(0, maxChars) : textInput;
+
+      const { response, payload } = await callHuggingFaceLocal(text);
+
+      if (response.status === 429) {
+        logger(requestId, 'hf_rate_limited', { status: 429 });
+        return safeError(res, 503, 'Hugging Face rate limit reached. Please retry shortly.');
+      }
+
+      if (response.status === 503) {
+        logger(requestId, 'hf_model_loading', { status: 503 });
+        return safeError(res, 503, 'Model is loading or unavailable. Please retry shortly.');
+      }
+
+      if (!response.ok) {
+        logger(requestId, 'hf_upstream_error', { status: response.status });
+        return safeError(res, 502, 'Upstream model error from Hugging Face.');
+      }
+
+      const rows = extractTokenRows(payload);
+      if (!Array.isArray(rows)) {
+        logger(requestId, 'hf_malformed_payload', { status: response.status });
+        return safeError(res, 502, 'Malformed response from upstream model provider.');
+      }
+
+      const tokens = rows.map(toToken);
+      const entities = mergeTokensToEntities(tokens);
+      const grouped = groupEntities(entities);
+      const latencyMs = now() - start;
+
+      logger(requestId, 'success', {
+        model: hfNerModel,
+        revision: modelRevision || 'default',
+        inputChars: text.length,
+        latencyMs,
+        entityCount: entities.length,
+      });
+
+      return json(res, 200, {
+        success: true,
+        model: {
+          name: hfNerModel,
+          revision: modelRevision || 'default',
+          labels: CATEGORY_LABELS,
+        },
+        limits: {
+          maxChars,
+          truncated,
+        },
+        entities,
+        grouped,
+        warnings: ['Assistive output; analyst review required.'],
+        telemetry: {
+          latencyMs,
+          emptyExtraction: entities.length === 0,
+          inputChars: text.length,
+          requestId,
+        },
+      });
+    } catch (error) {
+      const latencyMs = now() - start;
+      const timeout = error?.name === 'AbortError';
+      logger(requestId, 'internal_error', {
+        errorType: timeout ? 'timeout' : error?.name || 'unknown',
+        latencyMs,
+        model: hfNerModel || 'unset',
+        revision: modelRevision || 'default',
+      });
+      return safeError(res, timeout ? 504 : 500, timeout ? 'Inference timed out. Please retry.' : 'Internal server error.');
+    }
+  };
+
+  return { handler, port };
+};
+
+const { handler: defaultHandler, port: defaultPort } = createNerHandler();
+
+const server = createServer(async (req, res) => {
+  return defaultHandler(req, res);
+});
+
+server.listen(defaultPort, '127.0.0.1', () => {
+  console.log(`[ner] server listening on http://127.0.0.1:${defaultPort}`);
+});

--- a/services/nerService.ts
+++ b/services/nerService.ts
@@ -1,0 +1,73 @@
+export type NERCategory = 'ACTOR' | 'ASSET' | 'ACTION' | 'ATTRIBUTE' | 'OTHER';
+
+export interface NEREntity {
+  category: NERCategory;
+  text: string;
+  start: number | null;
+  end: number | null;
+  confidence: number | null;
+  source: 'model';
+  originalLabel?: string;
+  normalized?: {
+    veris?: Record<string, unknown>;
+  };
+}
+
+export interface NERResponse {
+  success: boolean;
+  model: {
+    name: string;
+    revision: string;
+    labels: NERCategory[];
+  };
+  limits: {
+    maxChars: number;
+    truncated: boolean;
+  };
+  entities: NEREntity[];
+  grouped: Record<NERCategory, NEREntity[]>;
+  warnings: string[];
+  telemetry: {
+    latencyMs: number;
+    emptyExtraction: boolean;
+    inputChars: number;
+    requestId: string;
+  };
+}
+
+export const runNerAnalysis = async (text: string): Promise<NERResponse> => {
+  const response = await fetch('/api/ner', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      text,
+      options: {
+        language: 'en',
+        returnSpans: true,
+      },
+    }),
+  });
+
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // noop
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof payload === 'object' && payload && 'error' in payload && typeof (payload as { error: unknown }).error === 'string'
+        ? (payload as { error: string }).error
+        : `NER request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid NER response payload.');
+  }
+
+  return payload as NERResponse;
+};


### PR DESCRIPTION
## Summary

Adds a backend-only Hugging Face NER integration for SOC incident narrative enrichment and aligns the frontend VERISBERTA NER UI with the new response contract.

## Changes

- Hardened \POST /api/ner\
- Added server-side Hugging Face config via \HF_API_TOKEN\, \HF_NER_MODEL\, \MODEL_REVISION\, and \NER_API_TIMEOUT_MS\
- Added safe handling for missing config, timeout, 429, 503/model loading, malformed upstream responses, and generic upstream failures
- Added BIO prefix stripping, alias mapping, unknown-label fallback, and subword-safe merge behavior
- Updated NER service types and UI metadata handling
- Added focused backend and UI tests

## Files changed

- \server/nerServer.js\
- \services/nerService.ts\
- \components/VerisBertaNerView.tsx\
- \__tests__/nerServer.test.ts\
- \__tests__/VerisBertaNerView.test.tsx\

## Required Environment Variables

\\\nv
HF_API_TOKEN=your_server_side_hugging_face_token
HF_NER_MODEL=your_token_classification_model_repo_id
MODEL_REVISION=main
NER_API_TIMEOUT_MS=8000
\\\

## Validation results

- Focused NER backend tests passing
- Focused VERISBERTA NER UI tests passing
- Branch pushed successfully to origin

## Known limitations

- Upstream model cold-start (503/loading) can still cause temporary unavailability despite graceful handling
- End-to-end quality remains dependent on selected Hugging Face token classification model behavior

## Out-of-scope notes

- No TODO.md changes included
- No roadmap updates included
- No unrelated \App.test.tsx\, error tracking, or formatting churn included
- No secrets or \.env\ files included